### PR TITLE
Better_slack_formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "PyYAML>=6.0.1",
     "slack_bolt>=1.18.1",
     "solace_ai_connector>=0.0.1",
+    "prettytable>=3.10.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PyYAML>=6.0.1
+slack_bolt>=1.18.1
+solace_ai_connector>=0.1.1
+prettytable>=3.10.0

--- a/src/solace_ai_connector_slack/components/slack_output.py
+++ b/src/solace_ai_connector_slack/components/slack_output.py
@@ -248,7 +248,7 @@ class SlackOutput(SlackBase):
         message = re.sub(r"\*\*(.*?)\*\*", r"*\1*", message)
 
         # Reformat a table to be Slack compatible
-        s
+        message = self.convert_markdown_tables(message)
 
         return message
 
@@ -278,7 +278,7 @@ class SlackOutput(SlackBase):
             if (now - state["create_time"]).total_seconds() > age:
                 del self.streaming_state[uuid]
 
-    def convert_markdown_tables(message):
+    def convert_markdown_tables(self, message):
         def markdown_to_fixed_width(match):
             table_str = match.group(0)
             rows = [
@@ -294,7 +294,7 @@ class SlackOutput(SlackBase):
             for row in rows[2:]:
                 pt.add_row([cell.strip() for cell in row if cell.strip()])
 
-            return f"```\n{pt.get_string()}\n```"
+            return f"\n```\n{pt.get_string()}\n```\n"
 
         pattern = r"\|.*\|[\n\r]+\|[-:| ]+\|[\n\r]+((?:\|.*\|[\n\r]+)+)"
         return re.sub(pattern, markdown_to_fixed_width, message)


### PR DESCRIPTION
Fix some formatting issues with markdown -> slack mkdown. The main change is to convert a markdown table into a fixed width table with appropriate padding