### PR TITLE
Fix handling of thread_ts and reply_to_thread in Slack messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ classifiers = [
 dependencies = [
     "PyYAML>=6.0.1",
     "slack_bolt>=1.18.1",
-    "solace_ai_connector>=0.1.3",
-    "prettytable>=3.10.0",
+    "solace_ai_connector>=0.1.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
 dependencies = [
     "PyYAML>=6.0.1",
     "slack_bolt>=1.18.1",
-    "solace_ai_connector>=0.1.1",
+    "solace_ai_connector>=0.1.3",
+    "prettytable>=3.10.0",
 ]
 
 [project.urls]

--- a/src/solace_ai_connector_slack/components/slack_input.py
+++ b/src/solace_ai_connector_slack/components/slack_input.py
@@ -270,13 +270,15 @@ class SlackReceiver(threading.Thread):
         user_email = self.get_user_email(event.get("user"))
         (text, mention_emails) = self.process_text_for_mentions(event["text"])
 
-        # Determine the thread_ts to put in the message
+        # Determine the reply_to thread to put in the message
         if event.get("channel_type") == "im" and event.get("subtype", event.get("type")) == "app_mention":
-            ts = event.get("ts")
+            # First message uses ts, subsequent messages use thread_ts
+            reply_to = event.get("thread_ts") or event.get("ts")
         else:
-            ts = None
+            # First message uses ts, subsequent messages use thread_ts
+            # thread_ts is null in direct messages
+            reply_to = event.get("thread_ts")
 
-        reply_to = event.get("thread_ts") or ts
         if reply_to:
             thread_id = f"{event.get("channel")}_{reply_to}"
         else:
@@ -291,10 +293,11 @@ class SlackReceiver(threading.Thread):
             "mentions": mention_emails,
             "type": event.get("type"),
             "client_msg_id": event.get("client_msg_id"),
-            "ts": ts,
+            "ts": event.get("ts"),
             "channel": event.get("channel"),
             "channel_name": event.get("channel_name", ""),
             "subtype": event.get("subtype"),
+            "event_ts": event.get("event_ts"),
             "thread_ts":  event.get("thread_ts"),
             "channel_type": event.get("channel_type"),
             "user_id": event.get("user"),
@@ -306,7 +309,7 @@ class SlackReceiver(threading.Thread):
             "team_id": event.get("team"),
             "type": event.get("type"),
             "client_msg_id": event.get("client_msg_id"),
-            "ts": ts,
+            "ts": event.get("ts"),
             "thread_ts": event.get("thread_ts"),
             "channel": event.get("channel"),
             "subtype": event.get("subtype"),

--- a/src/solace_ai_connector_slack/components/slack_output.py
+++ b/src/solace_ai_connector_slack/components/slack_output.py
@@ -153,7 +153,7 @@ class SlackOutput(SlackBase):
             messages = message.get_data("previous:text")
             stream = message.get_data("previous:stream")
             files = message.get_data("previous:files") or []
-            thread_ts = message.get_data("previous:ts")
+            thread_ts = message.get_data("previous:reply_to_thread") or message.get_data("previous:thread_ts")
             ack_msg_ts = message.get_data("previous:ack_msg_ts")
             first_streamed_chunk = message.get_data("previous:first_streamed_chunk")
             last_streamed_chunk = message.get_data("previous:last_streamed_chunk")


### PR DESCRIPTION
This pull request fixes an issue where the thread_ts and reply_to_thread values were not being properly handled in Slack messages. The commit "Passing slacks ts and thread_ts as is, and using reply_to_thread and thread_id for cm logic" ensures that the correct values are assigned to the thread_ts and reply_to_thread variables in the code. This resolves the problem of messages not being sent to the correct threads in Slack.