### PR TITLE
AI-347: Add thumbs up / thumbs down at the end of a response

### DIFF
--- a/src/solace_ai_connector_slack/components/slack_base.py
+++ b/src/solace_ai_connector_slack/components/slack_base.py
@@ -1,6 +1,10 @@
 """Base class for all Slack components"""
 
 from abc import ABC, abstractmethod
+import json
+import os
+import requests
+
 from slack_bolt import App  # pylint: disable=import-error
 from solace_ai_connector.components.component_base import ComponentBase
 
@@ -15,6 +19,9 @@ class SlackBase(ComponentBase, ABC):
         self.max_file_size = self.get_config("max_file_size", 20)
         self.max_total_file_size = self.get_config("max_total_file_size", 20)
         self.share_slack_connection = self.get_config("share_slack_connection")
+        self.feedback_enabled = self.get_config("feedback", False)
+        self.feedback_post_url = self.get_config("feedback_post_url", None)
+        self.feedback_post_headers = self.get_config("feedback_post_headers", {})
 
         if self.share_slack_connection:
             if self.slack_bot_token not in SlackBase._slack_apps:
@@ -34,3 +41,37 @@ class SlackBase(ComponentBase, ABC):
 
     def __repr__(self):
         return self.__str__()
+    
+    def register_action_handlers(self):
+        @self.app.action("thumbs_up_action")
+        def handle_thumbs_up(ack, body, say):
+            self.feedback(ack, body, say, "thumbs_up")
+
+        @self.app.action("thumbs_down_action")
+        def handle_thumbs_down(ack, body, say):
+            self.feedback(ack, body, say, "thumbs_down")
+
+    def feedback(self, ack, body, say, feedback):
+        # Acknowledge the action request
+        ack()
+        # Respond to the action
+        value_object = json.loads(body['actions'][0]['value'])
+        say(f"Thanks for the feedback, <@{body['user']['id']}>!")
+
+        rest_body = {
+            "user": body['user'],
+            "feedback": feedback,
+            "interface": "slack",
+            "channel": body['channel'],
+            "message": body['message'],
+            "data": value_object
+        }
+
+        try:
+            response = requests.post(
+                url=self.feedback_post_url,
+                headers=self.feedback_post_headers,
+                data=json.dumps(rest_body)
+            )
+        except Exception as e:
+            self.logger.error(f"Failed to post feedback: {str(e)}")

--- a/src/solace_ai_connector_slack/components/slack_base.py
+++ b/src/solace_ai_connector_slack/components/slack_base.py
@@ -55,6 +55,11 @@ class SlackBase(ComponentBase, ABC):
         # Acknowledge the action request
         ack()
 
+        # Check if feedback is enabled and the feedback post URL is set
+        if not self.feedback_enabled or not self.feedback_post_url:
+            self.logger.error("Feedback is not enabled or feedback post URL is not set.")
+            return
+        
         # Respond to the action
         value_object = json.loads(body['actions'][0]['value'])
         feedback_data = value_object.get("feedback_data", {})
@@ -66,6 +71,7 @@ class SlackBase(ComponentBase, ABC):
             thread_ts=thread_ts,
             text=f"Thanks for the feedback, <@{body['user']['id']}>!",
         )
+
         rest_body = {
             "user": body['user'],
             "feedback": feedback,
@@ -77,7 +83,7 @@ class SlackBase(ComponentBase, ABC):
         }
 
         try:
-            response = requests.post(
+            requests.post(
                 url=self.feedback_post_url,
                 headers=self.feedback_post_headers,
                 data=json.dumps(rest_body)

--- a/src/solace_ai_connector_slack/components/slack_base.py
+++ b/src/solace_ai_connector_slack/components/slack_base.py
@@ -62,7 +62,9 @@ class SlackBase(ComponentBase, ABC):
             "user": body['user'],
             "feedback": feedback,
             "interface": "slack",
-            "channel": body['channel'],
+            "interface_data": {
+                "channel": body['channel']
+            },
             "message": body['message'],
             "data": value_object
         }

--- a/src/solace_ai_connector_slack/components/slack_output.py
+++ b/src/solace_ai_connector_slack/components/slack_output.py
@@ -1,5 +1,6 @@
 import base64
 import re
+import json
 from datetime import datetime
 
 from prettytable import PrettyTable
@@ -35,6 +36,21 @@ info = {
             "description": "Correct markdown formatting in messages to conform to Slack markdown.",
             "default": "true",
         },
+        {
+            "name": "feedback",
+            "type": "boolean",
+            "description": "Collect thumbs up/thumbs down from users.",
+        },
+        {
+            "name": "feedback_post_url",
+            "type": "string",
+            "description": "URL to send feedback to.",
+        },
+        {
+            "name": "feedback_post_headers",
+            "type": "object",
+            "description": "Headers to send with feedback post.",
+        }
     ],
     "input_schema": {
         "type": "object",
@@ -117,6 +133,7 @@ class SlackOutput(SlackBase):
         super().__init__(info, **kwargs)
         self.fix_formatting = self.get_config("correct_markdown_formatting", True)
         self.streaming_state = {}
+        self.register_action_handlers()
 
     def invoke(self, message, data):
         content = data.get("content")
@@ -134,6 +151,8 @@ class SlackOutput(SlackBase):
         thread_ts = message_info.get("ts")
         channel = message_info.get("channel")
         ack_msg_ts = message_info.get("ack_msg_ts")
+
+        feedback_data = data.get("feedback_data", {})
 
         if response_complete:
             status_update = True
@@ -157,6 +176,8 @@ class SlackOutput(SlackBase):
             "status_update": status_update,
             "last_chunk": last_chunk,
             "first_chunk": first_chunk,
+            "response_complete": response_complete,
+            "feedback_data": feedback_data,
         }
 
     def send_message(self, message):
@@ -171,6 +192,8 @@ class SlackOutput(SlackBase):
             last_chunk = message.get_data("previous:last_chunk")
             uuid = message.get_data("previous:uuid")
             status_update = message.get_data("previous:status_update")
+            response_complete = message.get_data("previous:response_complete")
+            feedback_data = message.get_data("previous:feedback_data") or {}
 
             if not isinstance(messages, list):
                 if messages is not None:
@@ -255,6 +278,14 @@ class SlackOutput(SlackBase):
                     thread_ts=reply_to,
                     filename=file["name"],
                 )
+
+            if streaming and response_complete and self.feedback_enabled:
+                blocks = self.create_feedback_blocks(feedback_data)
+                response = self.app.client.chat_postMessage(
+                    channel=channel, text="feedback", thread_ts=reply_to, blocks=blocks
+                )
+
+
         except Exception as e:
             log.error("Error sending slack message: %s", e)
 
@@ -320,3 +351,33 @@ class SlackOutput(SlackBase):
 
         pattern = r"\|.*\|[\n\r]+\|[-:| ]+\|[\n\r]+((?:\|.*\|[\n\r]+)+)"
         return re.sub(pattern, markdown_to_fixed_width, message)
+
+    @staticmethod
+    def create_feedback_blocks(value_object):
+        return [
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "emoji": True,
+                            "text": "👍"
+                        },
+                        "value": json.dumps(value_object),
+                        "action_id": "thumbs_up_action"
+                    },
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "emoji": True,
+                            "text": "👎"
+                        },
+                        "value": json.dumps(value_object),
+                        "action_id": "thumbs_down_action"
+                    }
+                ]
+            }
+        ]

--- a/src/solace_ai_connector_slack/components/slack_output.py
+++ b/src/solace_ai_connector_slack/components/slack_output.py
@@ -280,7 +280,7 @@ class SlackOutput(SlackBase):
                 )
 
             if streaming and response_complete and self.feedback_enabled:
-                blocks = self.create_feedback_blocks(feedback_data)
+                blocks = self.create_feedback_blocks(feedback_data, channel, reply_to)
                 response = self.app.client.chat_postMessage(
                     channel=channel, text="feedback", thread_ts=reply_to, blocks=blocks
                 )
@@ -353,7 +353,12 @@ class SlackOutput(SlackBase):
         return re.sub(pattern, markdown_to_fixed_width, message)
 
     @staticmethod
-    def create_feedback_blocks(value_object):
+    def create_feedback_blocks(value_object, channel, thread_ts):
+        feedback_data = {
+            "channel": channel,
+            "thread_ts": thread_ts,
+            "feedback_data": value_object
+        }
         return [
             {
                 "type": "actions",
@@ -365,7 +370,7 @@ class SlackOutput(SlackBase):
                             "emoji": True,
                             "text": "👍"
                         },
-                        "value": json.dumps(value_object),
+                        "value": json.dumps(feedback_data),
                         "action_id": "thumbs_up_action"
                     },
                     {
@@ -375,7 +380,7 @@ class SlackOutput(SlackBase):
                             "emoji": True,
                             "text": "👎"
                         },
-                        "value": json.dumps(value_object),
+                        "value": json.dumps(feedback_data),
                         "action_id": "thumbs_down_action"
                     }
                 ]


### PR DESCRIPTION
## What is the purpose of this change?
Add the ability to collect user feedback through thumbs up/down reactions at the end of AI responses in Slack. This feedback is then sent to a configurable endpoint for analysis.

## How is this accomplished?
- Added feedback buttons (👍/👎) that appear after a complete response
- Implemented click handlers for the feedback buttons
- Created a REST endpoint integration to send feedback data
- Made feedback collection configurable through component settings

## Anything reviews should focus on/be aware of?
- Configuration for feedback is optional and disabled by default
- Error handling has been implemented for failed feedback submissions
- Feedback data includes user info, channel context, and the original message
- The REST endpoint and headers are configurable through component settings